### PR TITLE
Drop home manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,9 @@ Look at the [example](./example) directory for a working example.
 {
     inputs = {
         nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-        home-manager = {
-            url = "github:nix-community/home-manager";
-            inputs.nixpkgs.follows = "nixpkgs";
-        };
         modulix = {
             url = "github:anders130/modulix";
             inputs.nixpkgs.follows = "nixpkgs";
-            inputs.home-manager.follows = "home-manager";
         };
     };
 

--- a/docs/src/api/mkHosts.md
+++ b/docs/src/api/mkHosts.md
@@ -8,7 +8,7 @@ Arguments:
 
 - `inputs` : `{ ... }`
 
-  Inputs of the flake. Must contain `self`, `nixpkgs` and `home-manager`.
+  Inputs of the flake. Must contain `self` and `nixpkgs`.
 
 - (optional) `src` : `Path`
 

--- a/docs/src/api/mkSymlink.md
+++ b/docs/src/api/mkSymlink.md
@@ -2,29 +2,29 @@
 
 Source: [`src/mkSymlink.nix`](https://github.com/anders130/modulix/blob/master/src/mkSymlink.nix)
 
-Type: `(args : { ... }) -> Path -> { ... }`
+Type: `(hostArgs : { ... }) -> Path -> { ... }`
 
 Arguments:
 
-- `args` : `{ ... }`
+- `hostArgs` : `{ ... }`
 
-  This must contain the following attributes:
-
-  - `self` : `Path`
-
-    the flake path
+  The arguments passed into each file managed by `mkHosts`. It must contain the following attributes:
 
   - `flakePath` : `String`
 
     the flake path as absolute path
 
-  - `hmConfig` : `{ ... }`
-
-    the home-manager config of the current user
-
   - `isThinClient` : `Bool`
 
     whether the store path should be used instead of the flake path
+
+  - `pkgs` : `{ ... }`
+
+    the nixpkgs package set
+
+  - `self` : `Path`
+
+    the flake path
 
 - `path` : `Path`
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -16,14 +16,9 @@ Then add **modulix** to your flake inputs:
 {
     inputs = {
         nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-        home-manager = {
-            url = "github:nix-community/home-manager";
-            inputs.nixpkgs.follows = "nixpkgs";
-        };
         modulix = {
             url = "github:anders130/modulix";
             inputs.nixpkgs.follows = "nixpkgs";
-            inputs.home-manager.follows = "home-manager";
         };
     };
 
@@ -31,7 +26,7 @@ Then add **modulix** to your flake inputs:
 }
 ```
 
-> While overriding the `nixpkgs` and `home-manager` inputs is not required, it's recommended for consistency across your configuration.
+> While overriding the `nixpkgs` input is not required, it's recommended for consistency across your configuration.
 
 ## Using `mkHosts`
 

--- a/example/flake.lock
+++ b/example/flake.lock
@@ -46,16 +46,13 @@
     "modulix": {
       "inputs": {
         "haumea": "haumea",
-        "home-manager": [
-          "home-manager"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-UDG1X6mzEaYYbny7QTpUxoERX4YWzZmZ8Z30IIsy+ag=",
+        "narHash": "sha256-UnYsDhLO2deSsyPL3bcC2iNdm/HDgkEngQi/iCaCLAw=",
         "path": "../.",
         "type": "path"
       },

--- a/example/flake.nix
+++ b/example/flake.nix
@@ -10,7 +10,6 @@
         modulix = {
             url = "path:../.";
             inputs.nixpkgs.follows = "nixpkgs";
-            inputs.home-manager.follows = "home-manager";
         };
     };
 

--- a/flake.lock
+++ b/flake.lock
@@ -21,26 +21,6 @@
         "type": "github"
       }
     },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1739051380,
-        "narHash": "sha256-p1QSLO8DJnANY+ppK7fjD8GqfCrEIDjso1CSRHsXL7Y=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "5af1b9a0f193ab6138b89a8e0af8763c21bbf491",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1739020877,
@@ -60,7 +40,6 @@
     "root": {
       "inputs": {
         "haumea": "haumea",
-        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,6 @@
 
     inputs = {
         nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-        home-manager = {
-            url = "github:nix-community/home-manager";
-            inputs.nixpkgs.follows = "nixpkgs";
-        };
         haumea = {
             url = "github:nix-community/haumea/v0.2.2";
             inputs.nixpkgs.follows = "nixpkgs";
@@ -17,7 +13,6 @@
         checks = inputs.self.lib.recursiveLoadEvalTests {
             src = ./tests;
             inputs = {
-                inherit (inputs) home-manager;
                 inherit (inputs.nixpkgs) lib;
                 modulix = inputs.self.lib;
             };

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
         lib = inputs.haumea.lib.load {
             src = ./src;
             inputs = {
+                inherit inputs;
                 inherit (inputs.nixpkgs) lib;
                 haumea = inputs.haumea.lib;
             };

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
         lib = inputs.haumea.lib.load {
             src = ./src;
             inputs = {
-                inherit inputs;
                 inherit (inputs.nixpkgs) lib;
                 haumea = inputs.haumea.lib;
             };

--- a/src/internal/configure.nix
+++ b/src/internal/configure.nix
@@ -1,22 +1,11 @@
 {
     root,
     lib,
-}: {
-    config,
-    flakePath,
-    inputs,
-    isThinClient,
-    username,
-    ...
-}: helpers:
+}: hostArgs: helpers:
 lib # nixos
 // root # modulix
 // helpers # user defined stuff
 // { # better modulix
-    mkRelativePath = root.mkRelativePath inputs.self;
-    mkSymlink = root.mkSymlink {
-        inherit (inputs) self;
-        inherit isThinClient flakePath;
-        hmConfig = config.home-manager.users.${username};
-    };
+    mkRelativePath = root.mkRelativePath hostArgs.inputs.self;
+    mkSymlink = root.mkSymlink hostArgs;
 }

--- a/src/mkSymlink.nix
+++ b/src/mkSymlink.nix
@@ -1,17 +1,43 @@
-{root}: {
-    self,
-    flakePath,
-    hmConfig,
-    isThinClient,
-}: path: let
-    basePath = let s = toString self; in
-        if isThinClient then s
-        else if flakePath != null then flakePath
-        else builtins.warn "mkSymlink: flakePath not set, defaulting to self" s;
+{lib, root}: hostArgs: path: let
+    inherit (hostArgs) flakePath isThinClient pkgs;
+    inherit (hostArgs.inputs) self;
+    inherit (lib) escapeShellArg lowerChars stringToCharacters upperChars;
+    inherit (builtins) genList length replaceStrings warn;
+
+    basePath = let
+        s = toString self;
+    in
+        if isThinClient
+        then s
+        else if flakePath != null
+        then flakePath
+        else warn "mkSymlink: flakePath not set, defaulting to self" s;
+
+    # home-manager's mkOutOfStoreSymlink
+    mkOutOfStoreSymlink = path: let
+        storeFileName = path: let
+            # All characters that are considered safe. Note "-" is not
+            # included to avoid "-" followed by digit being interpreted as a
+            # version.
+            safeChars =
+                ["+" "." "_" "?" "="]
+                ++ lowerChars
+                ++ upperChars
+                ++ stringToCharacters "0123456789";
+
+            empties = l: genList (x: "") (length l);
+
+            unsafeInName = stringToCharacters (replaceStrings safeChars (empties safeChars) path);
+
+            safeName = replaceStrings unsafeInName (empties unsafeInName) path;
+        in
+            "hm_" + safeName;
+
+        pathStr = toString path;
+        name = storeFileName (baseNameOf pathStr);
+    in
+        pkgs.runCommandLocal name {} ''ln -s ${escapeShellArg pathStr} $out'';
 in {
     recursive = true; # important for directories but has no effect on files
-    source = path
-        |> root.mkRelativePath self
-        |> (p: "${basePath}/${p}")
-        |> hmConfig.lib.file.mkOutOfStoreSymlink;
+    source = mkOutOfStoreSymlink "${basePath}/${root.mkRelativePath self path}";
 }

--- a/tests/mkHosts/configuresLib/__fixture/hosts/host1/config.nix
+++ b/tests/mkHosts/configuresLib/__fixture/hosts/host1/config.nix
@@ -1,3 +1,1 @@
-{
-    username = "nixos";
-}
+{}

--- a/tests/mkHosts/configuresLib/__fixture/hosts/host1/default.nix
+++ b/tests/mkHosts/configuresLib/__fixture/hosts/host1/default.nix
@@ -1,3 +1,11 @@
 {lib, ...}: {
-    home-manager.users.nixos.home.file."test.txt" = lib.mkSymlink ./test.txt;
+    options.testFile = {
+        source = lib.mkOption {
+            type = lib.types.package;
+        };
+        recursive = lib.mkOption {
+            type = lib.types.bool;
+        };
+    };
+    config.testFile = lib.mkSymlink ./test.txt;
 }

--- a/tests/mkHosts/configuresLib/expected.nix
+++ b/tests/mkHosts/configuresLib/expected.nix
@@ -1,13 +1,7 @@
 {
     # result of mkSymlink called within host
     host1 = {
-        enable = true;
-        executable = null;
-        force = false;
-        onChange = "";
         recursive = true;
         source = "derivation";
-        target = "test.txt";
-        text = null;
     };
 }

--- a/tests/mkHosts/configuresLib/expr.nix
+++ b/tests/mkHosts/configuresLib/expr.nix
@@ -1,14 +1,9 @@
-{home-manager, modulix}: modulix.mkHosts {
+{modulix}: modulix.mkHosts {
     inputs.self = ./__fixture;
     flakePath = "/home/user1/project";
-    sharedConfig = {
-        imports = [home-manager.nixosModules.home-manager];
-        users.users.nixos.isNormalUser = true;
-        home-manager.users.nixos.home.stateVersion = "24.11";
-    };
 }
 |> builtins.mapAttrs (_: y:
-    y.config.home-manager.users.nixos.home.file."test.txt"
+    y.config.testFile
     |> (x: x // {
         source = x.source.type;
     })

--- a/tests/mkSymlink/_deps.nix
+++ b/tests/mkSymlink/_deps.nix
@@ -1,0 +1,21 @@
+{lib}: {
+    args = {
+        inputs.self = ./.;
+        isThinClient = false;
+        pkgs.runCommandLocal = name: _: command: {inherit name command;};
+    };
+
+    process = result: let
+        path = result.source.command
+            |> lib.strings.splitString " "
+            |> (l: builtins.elemAt l 2)
+            |> lib.strings.removePrefix (toString ./.)
+            ;
+    in {
+        inherit (result) recursive;
+        source = {
+            inherit path;
+            inherit (result.source) name;
+        };
+    };
+}

--- a/tests/mkSymlink/basic/expected.nix
+++ b/tests/mkSymlink/basic/expected.nix
@@ -1,4 +1,7 @@
 {
     recursive = true;
-    source = "/home/user1/project/example";
+    source = {
+        name = "hm_example";
+        path = "/home/user1/project/basic/example";
+    };
 }

--- a/tests/mkSymlink/basic/expr.nix
+++ b/tests/mkSymlink/basic/expr.nix
@@ -1,8 +1,9 @@
-{modulix}: let
-    args = {
-        self = ./.;
-        flakePath = "/home/user1/project";
-        isThinClient = false;
-        hmConfig.lib.file.mkOutOfStoreSymlink = p: p; # mock for testing
-    };
-in modulix.mkSymlink args ./example
+{
+    modulix,
+    root,
+}: let
+    inherit (root.mkSymlink.deps) args process;
+    args' = args // {flakePath = "/home/user1/project";};
+in
+    modulix.mkSymlink args' ./example
+    |> process

--- a/tests/mkSymlink/isThinClientTrue/expected.nix
+++ b/tests/mkSymlink/isThinClientTrue/expected.nix
@@ -1,4 +1,7 @@
 {
     recursive = true;
-    source = "/example"; # should be relative to self
+    source = {
+        name = "hm_example";
+        path = "/isThinClientTrue/example";
+    };
 }

--- a/tests/mkSymlink/isThinClientTrue/expr.nix
+++ b/tests/mkSymlink/isThinClientTrue/expr.nix
@@ -1,12 +1,12 @@
-{lib, modulix}: let
-    args = {
-        self = ./.;
+{
+    modulix,
+    root,
+}: let
+    inherit (root.mkSymlink.deps) args process;
+    args' = args // {
         flakePath = "/home/user1/project";
         isThinClient = true;
-        hmConfig.lib.file.mkOutOfStoreSymlink = p: p; # mock for testing
     };
-in modulix.mkSymlink args ./example
-|> (x: x // {
-    # remove the self path from the source for comparison in expected.nix
-    source = lib.strings.removePrefix (toString args.self) x.source;
-})
+in
+    modulix.mkSymlink args' ./example
+    |> process

--- a/tests/mkSymlink/noFlakePath/expected.nix
+++ b/tests/mkSymlink/noFlakePath/expected.nix
@@ -1,4 +1,7 @@
 {
     recursive = true;
-    source = "/example"; # should be relative to self
+    source = {
+        name = "hm_example";
+        path = "/noFlakePath/example";
+    };
 }

--- a/tests/mkSymlink/noFlakePath/expr.nix
+++ b/tests/mkSymlink/noFlakePath/expr.nix
@@ -1,12 +1,9 @@
-{lib, modulix}: let
-    args = {
-        self = ./.;
-        flakePath = null;
-        isThinClient = false;
-        hmConfig.lib.file.mkOutOfStoreSymlink = p: p; # mock for testing
-    };
-in modulix.mkSymlink args ./example
-|> (x: x // {
-    # remove the self path from the source for comparison in expected.nix
-    source = lib.strings.removePrefix (toString args.self) x.source;
-})
+{
+    modulix,
+    root
+}: let
+    inherit (root.mkSymlink.deps) args process;
+    args' = args // {flakePath = null;};
+in
+    modulix.mkSymlink args' ./example
+    |> process


### PR DESCRIPTION
This pull request removes the `home-manager` dependency. The `mkSymlink` function previously required the function `config.home-manager.${username}.lib.file.mkOutOfStoreSymlink` which is now reimplemented in this library without needing home-manager anymore.

Also the `mkSymlink` function now receives the normal `hostArgs` passed to each file as first argument instead of relying on a custom set that included the `home-manager`-config.

To make this change possible, some tests were adjusted to the new inputs of `mkSymlink`. Also the documentation and examples don't mention home-manager anymore.